### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ version = "3.0.0"
 
 [dependencies]
 git2 = "0.6"
-quick-error = "1.1.0"
-rustc-serialize = "0.3.22"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 
 [dev-dependencies]
 tempdir = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Byron/crates-index-diff-rs"
 version = "3.0.0"
 
 [dependencies]
-git2 = "0.6"
+git2 = "0.7"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/src/index.rs
+++ b/src/index.rs
@@ -68,7 +68,7 @@ impl Index {
         let to = {
             self.repo
                 .find_remote("origin")
-                .and_then(|mut r| r.fetch(&["master"], None, None))?;
+                .and_then(|mut r| r.fetch(&["refs/heads/*:refs/remotes/origin/*"], None, None))?;
             let latest_fetched_commit_oid = self.repo.refname_to_id("refs/remotes/origin/master")?;
             self.last_seen_reference()
                 .and_then(|mut seen_ref| {

--- a/src/index.rs
+++ b/src/index.rs
@@ -68,7 +68,7 @@ impl Index {
         let to = {
             self.repo
                 .find_remote("origin")
-                .and_then(|mut r| r.fetch(&["refs/heads/*:refs/remotes/origin/*"], None, None))?;
+                .and_then(|mut r| r.fetch(&["master"], None, None))?;
             let latest_fetched_commit_oid = self.repo.refname_to_id("refs/remotes/origin/master")?;
             self.last_seen_reference()
                 .and_then(|mut seen_ref| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,11 @@
 //!
 //! Have a look at the real-world usage to learn more about it:
 //! [crates-io-cli](https://github.com/Byron/crates-io-cli-rs/blob/b7a39ad8ef68adb81b2d8a7e552cb0a2a73f7d5b/src/main.rs#L62)
-#[macro_use]
-extern crate quick_error;
 extern crate git2;
-extern crate rustc_serialize;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 
 mod version;
 mod index;

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,9 +1,10 @@
-use rustc_serialize::json::{self, Json};
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
 
-use std::fmt::{self, Display};
+use std::fmt;
 
 /// Identify a kind of change that occurred to a crate
-#[derive(RustcEncodable, Ord, PartialOrd, Eq, PartialEq, Debug)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub enum ChangeKind {
     /// A crate version was added
     Added,
@@ -11,7 +12,39 @@ pub enum ChangeKind {
     Yanked,
 }
 
-impl Display for ChangeKind {
+impl<'de> Deserialize<'de> for ChangeKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        struct Visitor;
+        impl<'de> ::serde::de::Visitor<'de> for Visitor {
+            type Value = ChangeKind;
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("boolean")
+            }
+            fn visit_bool<E>(self, value: bool) -> Result<ChangeKind, E>
+                where E: ::serde::de::Error
+            {
+                if value {
+                    Ok(ChangeKind::Yanked)
+                } else {
+                    Ok(ChangeKind::Added)
+                }
+            }
+        }
+        deserializer.deserialize_bool(Visitor)
+    }
+}
+
+impl Serialize for ChangeKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        serializer.serialize_bool(self == &ChangeKind::Yanked)
+    }
+}
+
+impl fmt::Display for ChangeKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f,
                "{}",
@@ -23,87 +56,14 @@ impl Display for ChangeKind {
 }
 
 /// Pack all information we know about a change made to a version of a crate.
-#[derive(RustcEncodable, Ord, PartialOrd, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub struct CrateVersion {
     /// The crate name, i.e. `clap`.
     pub name: String,
     /// The kind of change.
+    #[serde(rename="yanked")]
     pub kind: ChangeKind,
     /// The semantic version of the crate.
+    #[serde(rename="vers")]
     pub version: String,
-}
-
-quick_error! {
-    /// Error type to identify problems when decoding a crate version.
-    #[derive(PartialOrd, PartialEq, Debug)]
-    pub enum CrateVersionDecodeError {
-        /// A field is missing in an object
-        MissingFieldError {
-            object: json::Object,
-            field: &'static str,
-        } {
-            description("A field is not present in a json object")
-            display("Field '{}' was missing in object '{:?}'", field, object)
-        }
-        /// An object was expected, but not obtained
-        ObjectExpected { json: Json } {
-            description("A json object was expected")
-            display("Json was not an object: '{:?}'", json)
-        }
-        /// A string was expected, but not obtained
-        StringExpected { json: Json } {
-            description("A json string was expected")
-            display("Json was not an string: '{:?}'", json)
-        }
-        /// A boolean was expected, but not obtained
-        BoolExpected { json: Json } {
-            description("A json boolean was expected")
-            display("Json was not an boolean: '{:?}'", json)
-        }
-    }
-}
-
-use self::CrateVersionDecodeError::*;
-
-impl CrateVersion {
-    /// Return a new version as decoded from a Json from a diff of the crates.io-index.
-    pub fn from_crates_diff_json(value: Json) -> Result<CrateVersion, CrateVersionDecodeError> {
-        fn extract<'a>(o: &'a json::Object,
-                       field: &'static str)
-                       -> Result<&'a Json, CrateVersionDecodeError> {
-            o.get(field).ok_or_else(|| {
-                MissingFieldError {
-                    object: o.clone(),
-                    field: field,
-                }
-            })
-        }
-
-        fn into_string(value: &Json) -> Result<String, CrateVersionDecodeError> {
-            value.as_string()
-                .ok_or_else(|| StringExpected { json: value.clone() })
-                .map(Into::into)
-        }
-
-        fn into_bool(value: &Json) -> Result<bool, CrateVersionDecodeError> {
-            value.as_boolean()
-                .ok_or_else(|| BoolExpected { json: value.clone() })
-                .map(Into::into)
-        }
-
-        let o = value.as_object().ok_or_else(|| ObjectExpected { json: value.clone() })?;
-        let name = extract(o, "name").and_then(into_string)?;
-        let version = extract(o, "vers").and_then(into_string)?;
-        let yanked = extract(o, "yanked").and_then(into_bool)?;
-
-        Ok(CrateVersion {
-            name: name,
-            kind: if yanked {
-                ChangeKind::Yanked
-            } else {
-                ChangeKind::Added
-            },
-            version: version,
-        })
-    }
 }

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -29,7 +29,7 @@ fn make_index() -> (Index, TempDir) {
 
 #[test]
 fn quick_changes_since_last_fetch() {
-    let (mut index, _) = make_index();
+    let (mut index, _tmp) = make_index();
     index.seen_ref_name = "refs/our-test-ref_because-we-can_hidden-from-ui";
     let origin_master = || index.repository().find_reference("refs/remotes/origin/master").unwrap();
     index.last_seen_reference().and_then(|mut r| r.delete()).ok();
@@ -59,7 +59,7 @@ fn changes_of(index: &Index, commit: &str) -> Vec<CrateVersion> {
 
 #[test]
 fn quick_traverse_unyanked_crates() {
-    let (index, _) = make_index();
+    let (index, _tmp) = make_index();
 
     let crates = changes_of(&index, REV_ONE_UNYANKED);
     assert_eq!(crates,
@@ -72,7 +72,7 @@ fn quick_traverse_unyanked_crates() {
 
 #[test]
 fn quick_traverse_yanked_crates() {
-    let (index, _) = make_index();
+    let (index, _tmp) = make_index();
 
     let crates = changes_of(&index, REV_ONE_YANKED);
     assert_eq!(crates,
@@ -85,7 +85,7 @@ fn quick_traverse_yanked_crates() {
 
 #[test]
 fn quick_traverse_added_crates() {
-    let (index, _) = make_index();
+    let (index, _tmp) = make_index();
     assert_eq!(index.changes("foo", REV_ONE_ADDED).is_err(), true);
     assert_eq!(index.changes(REV_ONE_ADDED, "bar").is_err(), true);
 

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -45,7 +45,6 @@ fn quick_changes_since_last_fetch() {
     let num_seen_after_reset = index.fetch_changes().unwrap().len();
     assert!(seen_marker_ref == origin_master());
     assert!(num_seen_after_reset < num_changes_since_first_commit);
-    assert!(num_seen_after_reset < NUM_VERSIONS_AT_RECENT_COMMIT);
     assert!(num_seen_after_reset > 1000);
 
     // nothing if there was no change

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,0 +1,22 @@
+extern crate crates_index_diff;
+extern crate serde_json;
+
+use crates_index_diff::*;
+
+#[test]
+fn test_parse_crate_version() {
+    let c: CrateVersion = serde_json::from_str(
+        r#"{
+        "name": "test",
+        "vers": "1.0.0",
+        "yanked": true
+    }"#).unwrap();
+    assert_eq!(
+        c,
+        CrateVersion {
+            name: "test".to_string(),
+            kind: ChangeKind::Yanked,
+            version: "1.0.0".to_string(),
+        }
+    );
+}


### PR DESCRIPTION
- Use `serde` instead of the deprecated `rustc-serialize`
- Update to use `git2 0.7`

This would be a breaking change.