### PR TITLE
bump `git2` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Byron/crates-index-diff-rs"
 version = "4.0.0"
 
 [dependencies]
-git2 = "0.7"
+git2 = "0.9"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"


### PR DESCRIPTION
When updating the `cargo` library on docs.rs, i hit a conflict when linking against `libgit2`, since Cargo started using `git2` version 0.9 (linking via `libgit2-sys` 0.8) but this crate was using `git2` version 0.7 (linking via `libgit2-sys` 0.7). It looks like bumping the `git2` version doesn't cause any breakage, at least when building and running tests.