### PR TITLE
Disable unused ssh git feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,14 @@ readme = "changelog.md"
 include = ["src/**/*.rs", "Cargo.toml", "README.md", "changelog.md", "LINCENSE.md"]
 
 [dependencies]
-git2 = "0.13.0"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+
+[dependencies.git2]
+version = "0.13.0"
+default-features = false
+features = ["https"]
 
 [dev-dependencies]
 tempdir = "0.3.5"


### PR DESCRIPTION
git2 by default enables the `ssh` and `ssh_key_from_memory` features,
which pull in all of `libssh2-sys` as a result. This disables the unused
feature, reducing the dependencies used by crates_index_diff.