### PR TITLE
Only fetch the master crates.io branch, not all branches

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -180,7 +180,7 @@ impl Index {
             .or_else(|_| Oid::from_str(EMPTY_TREE_HASH))?;
         let to = {
             self.repo.find_remote("origin").and_then(|mut r| {
-                r.fetch(&["refs/heads/*:refs/remotes/origin/*"], options, None)
+                r.fetch(&["refs/heads/master:refs/remotes/origin/master"], options, None)
             })?;
             let latest_fetched_commit_oid =
                 self.repo.refname_to_id("refs/remotes/origin/master")?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -180,7 +180,11 @@ impl Index {
             .or_else(|_| Oid::from_str(EMPTY_TREE_HASH))?;
         let to = {
             self.repo.find_remote("origin").and_then(|mut r| {
-                r.fetch(&["refs/heads/master:refs/remotes/origin/master"], options, None)
+                r.fetch(
+                    &["refs/heads/master:refs/remotes/origin/master"],
+                    options,
+                    None,
+                )
             })?;
             let latest_fetched_commit_oid =
                 self.repo.refname_to_id("refs/remotes/origin/master")?;

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -67,7 +67,15 @@ fn quick_changes_since_last_fetch() {
         )
         .expect("reset success");
     let num_seen_after_reset = index.fetch_changes().unwrap().len();
-    assert!(seen_marker_ref == origin_master_of(&index));
+    let origin_master = origin_master_of(&index);
+    assert!(
+        seen_marker_ref == origin_master,
+        "{} ({}) != {} ({})",
+        seen_marker_ref.name().unwrap(),
+        seen_marker_ref.peel_to_commit().unwrap().id(),
+        origin_master.name().unwrap(),
+        origin_master.peel_to_commit().unwrap().id()
+    );
     assert!(num_seen_after_reset < num_changes_since_first_commit);
     assert!(num_seen_after_reset > 1000);
 


### PR DESCRIPTION
This shrinks the data downloaded for a first fetch from 752 to 94 MB.

cc @Nemo157