### PR TITLE
upgrade git2 to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_derive = "1"
 serde_json = "1"
 
 [dependencies.git2]
-version = "0.13.0"
+version = "0.14.0"
 default-features = false
 features = ["https"]
 


### PR DESCRIPTION
I was upgrading dependencies for in docs.rs, and stumbled onto this issue. 

Problem is that `git2` upgraded `libgit2-sys` to `1.4.0`, which then leads to a conflict (_failed to select a version for `libgit2-sys`_) when an application has the `git2==0.14.0` in its dependencies. 