### PR TITLE
refactor logic to handle crate-deletes

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -1,67 +1,27 @@
-use serde::de::{Deserialize, Deserializer};
-use serde::ser::{Serialize, Serializer};
 use std::collections::HashMap;
 
 use std::fmt;
 
 /// Identify a kind of change that occurred to a crate
-#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Debug)]
-pub enum ChangeKind {
-    /// A crate version was added
-    Added,
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum Change {
     /// A crate version was added or it was unyanked.
-    Yanked,
+    Added(CrateVersion),
+    /// A crate version was yanked.
+    Yanked(CrateVersion),
+    /// A crate was deleted
+    Deleted(String),
 }
 
-impl Default for ChangeKind {
-    fn default() -> Self {
-        ChangeKind::Added
-    }
-}
-
-impl<'de> Deserialize<'de> for ChangeKind {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct Visitor;
-        impl<'de> ::serde::de::Visitor<'de> for Visitor {
-            type Value = ChangeKind;
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("boolean")
-            }
-            fn visit_bool<E>(self, value: bool) -> Result<ChangeKind, E>
-            where
-                E: ::serde::de::Error,
-            {
-                if value {
-                    Ok(ChangeKind::Yanked)
-                } else {
-                    Ok(ChangeKind::Added)
-                }
-            }
-        }
-        deserializer.deserialize_bool(Visitor)
-    }
-}
-
-impl Serialize for ChangeKind {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_bool(self == &ChangeKind::Yanked)
-    }
-}
-
-impl fmt::Display for ChangeKind {
+impl fmt::Display for Change {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{}",
             match *self {
-                ChangeKind::Added => "added",
-                ChangeKind::Yanked => "yanked",
+                Change::Added(_) => "added",
+                Change::Yanked(_) => "yanked",
+                Change::Deleted(_) => "deleted",
             }
         )
     }
@@ -72,9 +32,8 @@ impl fmt::Display for ChangeKind {
 pub struct CrateVersion {
     /// The crate name, i.e. `clap`.
     pub name: String,
-    /// The kind of change.
-    #[serde(rename = "yanked")]
-    pub kind: ChangeKind,
+    /// is the release yanked?
+    pub yanked: bool,
     /// The semantic version of the crate.
     #[serde(rename = "vers")]
     pub version: String,

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -8,6 +8,7 @@ const NUM_VERSIONS_AT_RECENT_COMMIT: usize = 39752;
 const REV_ONE_ADDED: &'static str = "615c9c41942a3ba13e088fbcb1470c61b169a187";
 const REV_ONE_YANKED: &'static str = "8cf8fbad7876586ced34c4b778f6a80fadd2a59b";
 const REV_ONE_UNYANKED: &'static str = "f8cb00181";
+const REV_CRATE_DELETE: &str = "de5be3e8bb6cd7a3179857bdbdf28ca4fa23f84c";
 
 #[test]
 #[ignore] // This test takes too long for my taste, this library is stable by now
@@ -106,10 +107,18 @@ fn peek_changes_since_last_fetch() {
     );
 }
 
-fn changes_of(index: &Index, commit: &str) -> Vec<CrateVersion> {
+fn changes_of(index: &Index, commit: &str) -> Vec<Change> {
     index
-        .changes(format!("{}~1^{{tree}}", commit), format!("{}", commit))
+        .changes(format!("{}~1^{{tree}}", commit), commit)
         .expect("id to be valid and diff OK")
+}
+
+#[test]
+fn crate_delete() {
+    let (index, _tmp) = make_index();
+
+    let changes = changes_of(&index, REV_CRATE_DELETE);
+    assert_eq!(changes, vec![Change::Deleted("rustdecimal".to_string())],);
 }
 
 #[test]
@@ -121,9 +130,9 @@ fn quick_traverse_unyanked_crates() {
     let crates = changes_of(&index, REV_ONE_UNYANKED);
     assert_eq!(
         crates,
-        vec![CrateVersion {
+        vec![Change::Added(CrateVersion {
             name: "gfx_text".to_owned(),
-            kind: ChangeKind::Added,
+            yanked: false,
             version: "0.13.2".to_owned(),
             dependencies: vec![
                 Dependency {
@@ -174,7 +183,7 @@ fn quick_traverse_unyanked_crates() {
                 h
             },
             checksum: "d0b1240e3627e646f69685ddd3e7d83dd3ff3d586afe83bf3679082028183f2d".into(),
-        }]
+        })]
     );
 }
 
@@ -186,14 +195,14 @@ fn quick_traverse_yanked_crates() {
     let crates = changes_of(&index, REV_ONE_YANKED);
     assert_eq!(
         crates,
-        vec![CrateVersion {
+        vec![Change::Yanked(CrateVersion {
             name: "sha3".to_owned(),
-            kind: ChangeKind::Yanked,
+            yanked: true,
             version: "0.0.0".to_owned(),
             dependencies: Vec::new(),
             features: HashMap::new(),
             checksum: "dbba9d72d3d04e2167fb9c76ce22aed118eb003727bbe59774b9bf3603fa1f43".into(),
-        }]
+        })]
     );
 }
 
@@ -207,9 +216,9 @@ fn quick_traverse_added_crates() {
     let crates = changes_of(&index, REV_ONE_ADDED);
     assert_eq!(
         crates,
-        vec![CrateVersion {
+        vec![Change::Added(CrateVersion {
             name: "rpwg".to_owned(),
-            kind: ChangeKind::Added,
+            yanked: false,
             version: "0.1.0".to_owned(),
             dependencies: vec![
                 Dependency {
@@ -235,6 +244,6 @@ fn quick_traverse_added_crates() {
             ],
             features: HashMap::new(),
             checksum: "14437a3702699dba0c49ddc401a0529898e83f8b769348549985a0f4d818d3ca".into(),
-        }]
+        })]
     );
 }

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -18,7 +18,7 @@ fn test_parse_crate_version() {
         c,
         CrateVersion {
             name: "test".to_string(),
-            kind: ChangeKind::Yanked,
+            yanked: true,
             version: "1.0.0".to_string(),
             dependencies: Vec::new(),
             features: HashMap::new(),


### PR DESCRIPTION
sometimes crates are deleted completely by the crates.io team. This can be due to security issues ([`rustdecimal` is  a current example](https://blog.rust-lang.org/2022/05/10/malicious-crate-rustdecimal.html)), DCMA or GDPR requests. 

In docs.rs we're using this library and I want to handle crate deletes automatically when crates.io deletes the crate from the index. 

I'm aware this is a breaking change, though I'm not sure how this could look like in a compatible change. 

I'm OK if you don't want to break the API, then I would create a fork or copy the needed code over to the docs.rs repo. 