### PR TITLE
remove git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md"]
 test = false
 
 [dependencies]
-git-repository = { version = "0.24.0", default-features = false, features = ["max-performance-safe"] }
+git-repository = { version = "0.24.0", default-features = false, features = ["max-performance-safe", "blocking-network-client", "blocking-http-transport"], git = "https://github.com/byron/gitoxide" }
 similar = { version = "2.2.0", features = ["bytes"] }
 serde = { version = "1", features = ["std", "derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md"]
 test = false
 
 [dependencies]
-git-repository = { version = "0.24.0", default-features = false, features = ["max-performance-safe", "blocking-network-client", "blocking-http-transport"], git = "https://github.com/byron/gitoxide" }
+git-repository = { version = "0.25.0", default-features = false, features = ["max-performance-safe", "blocking-network-client", "blocking-http-transport"] }
 similar = { version = "2.2.0", features = ["bytes"] }
 serde = { version = "1", features = ["std", "derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,6 @@ serde_json = "1"
 bstr = "1.0.1"
 thiserror = "1.0.32"
 
-[dependencies.git2]
-version = "0.14.0"
-default-features = false
-features = ["https"]
-
 [dev-dependencies]
 git-testtools = "0.8.0"
 tempdir = "0.3.5"

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,5 @@ CARGO = $(shell command -v cargo)
 ##@ Development
 
 test: ## run all tests with cargo
-	RUST_BACKTRACE=1 cargo test --jobs 1
-	
-quick-test: ## run all fast tests with cargo (those which dont clone themselves
-	cargo test --jobs 1 quick
+	RUST_BACKTRACE=1 cargo test 
 	

--- a/src/index/diff/mod.rs
+++ b/src/index/diff/mod.rs
@@ -186,7 +186,7 @@ impl Index {
                     .replace_refspecs(Some(spec.as_str()), git::remote::Direction::Fetch)
                     .expect("valid statically known refspec");
             }
-            let res: git::remote::fetch::Outcome<'_> = remote
+            let res: git::remote::fetch::Outcome = remote
                 .connect(git::remote::Direction::Fetch, progress)?
                 .prepare_fetch(Default::default())?
                 .receive(should_interrupt)?;

--- a/src/index/init.rs
+++ b/src/index/init.rs
@@ -88,7 +88,7 @@ impl Index {
         repo.object_cache_size_if_unset(4 * 1024 * 1024);
         Ok(Index {
             repo,
-            remote_name: "origin",
+            remote_name: Some("origin"),
             branch_name: "master",
             seen_ref_name: LAST_SEEN_REFNAME,
         })

--- a/src/index/init.rs
+++ b/src/index/init.rs
@@ -1,18 +1,8 @@
-use crate::index::{CloneOptions, CloneOptions2, LAST_SEEN_REFNAME};
+use crate::index::{CloneOptions, LAST_SEEN_REFNAME};
 use crate::Index;
 use git_repository as git;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
-
-/// The error returned by various initialization methods.
-#[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
-pub enum Error {
-    #[error(transparent)]
-    Clone(#[from] git2::Error),
-    #[error(transparent)]
-    Open(#[from] git::open::Error),
-}
 
 /// The error returned by various initialization methods.
 #[derive(Debug, thiserror::Error)]
@@ -28,85 +18,6 @@ pub enum Error2 {
 
 /// Initialization
 impl Index {
-    /// Return a new `Index` instance from the given `path`, which should contain a bare or non-bare
-    /// clone of the `crates.io` index.
-    /// If the directory does not contain the repository or does not exist, it will be cloned from
-    /// the official location automatically (with complete history).
-    ///
-    /// An error will occour if the repository exists and the remote URL does not match the given repository URL.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use crates_index_diff::{Index, index};
-    ///
-    /// # let path = tempdir::TempDir::new("index").unwrap();
-    /// let mut options = index::CloneOptions {
-    ///   repository_url: "https://github.com/rust-lang/staging.crates.io-index".into(),
-    ///   ..Default::default()
-    /// };
-    ///
-    ///
-    /// let index = Index::from_path_or_cloned_with_options(path, options)?;
-    /// # Ok::<(), crates_index_diff::index::init::Error>(())
-    /// ```
-    /// Or to access a private repository, use fetch options.
-    ///
-    /// ```no_run
-    /// use crates_index_diff::{index, Index};
-    /// let fo = {
-    ///     let mut fo = git2::FetchOptions::new();
-    ///     fo.remote_callbacks({
-    ///         let mut callbacks = git2::RemoteCallbacks::new();
-    ///         callbacks.credentials(|_url, username_from_url, _allowed_types| {
-    ///             git2::Cred::ssh_key_from_memory(
-    ///                 username_from_url.unwrap(),
-    ///                 None,
-    ///                 &std::env::var("PRIVATE_KEY").unwrap(),
-    ///                 None,
-    ///             )
-    ///         });
-    ///         callbacks
-    ///     });
-    ///     fo
-    /// };
-    /// Index::from_path_or_cloned_with_options(
-    ///     "index",
-    ///     index::CloneOptions {
-    ///         repository_url: "git@github.com:private-index/goes-here.git".into(),
-    ///         fetch_options: Some(fo),
-    ///     },
-    /// ).unwrap();
-    /// ```
-    pub fn from_path_or_cloned_with_options(
-        path: impl AsRef<Path>,
-        CloneOptions {
-            repository_url,
-            fetch_options,
-        }: CloneOptions<'_>,
-    ) -> Result<Index, Error> {
-        let repo = git2::Repository::open(path.as_ref()).or_else(|err| {
-            if err.class() == git2::ErrorClass::Repository {
-                let mut builder = git2::build::RepoBuilder::new();
-                if let Some(fo) = fetch_options {
-                    builder.fetch_options(fo);
-                }
-                builder.bare(true).clone(&repository_url, path.as_ref())
-            } else {
-                Err(err)
-            }
-        })?;
-
-        let mut repo = git::open(repo.path())?.apply_environment();
-        repo.object_cache_size_if_unset(4 * 1024 * 1024);
-        Ok(Index {
-            repo,
-            remote_name: Some("origin".into()),
-            branch_name: "master",
-            seen_ref_name: LAST_SEEN_REFNAME,
-        })
-    }
-
     /// Return a new `Index` instance from the given `path`, which should contain a bare clone of the `crates.io` index.
     /// If the directory does not contain the repository or does not exist, it will be cloned from
     /// the official location automatically (with complete history).
@@ -121,19 +32,19 @@ impl Index {
     ///
     /// # let path = tempdir::TempDir::new("index").unwrap();
     /// // Note that credentials are automatically picked up from the standard git configuration.
-    /// let mut options = index::CloneOptions2 {
+    /// let mut options = index::CloneOptions {
     ///   url: "https://github.com/rust-lang/staging.crates.io-index".into(),
     /// };
     ///
     ///
-    /// let index = Index::from_path_or_cloned_with_options2(path, git::progress::Discard, &AtomicBool::default(), options)?;
+    /// let index = Index::from_path_or_cloned_with_options(path, git::progress::Discard, &AtomicBool::default(), options)?;
     /// # Ok::<(), crates_index_diff::index::init::Error2>(())
     /// ```
-    pub fn from_path_or_cloned_with_options2(
+    pub fn from_path_or_cloned_with_options(
         path: impl AsRef<Path>,
         progress: impl git::Progress,
         should_interrupt: &AtomicBool,
-        CloneOptions2 { url }: CloneOptions2,
+        CloneOptions { url }: CloneOptions,
     ) -> Result<Index, Error2> {
         let path = path.as_ref();
         let mut repo = match git::open(path) {
@@ -165,20 +76,12 @@ impl Index {
     /// clone of the `crates.io` index.
     /// If the directory does not contain the repository or does not exist, it will be cloned from
     /// the official location automatically (with complete history).
-    pub fn from_path_or_cloned2(path: impl AsRef<Path>) -> Result<Index, Error2> {
-        Index::from_path_or_cloned_with_options2(
+    pub fn from_path_or_cloned(path: impl AsRef<Path>) -> Result<Index, Error2> {
+        Index::from_path_or_cloned_with_options(
             path,
             git::progress::Discard,
             &AtomicBool::default(),
-            CloneOptions2::default(),
+            CloneOptions::default(),
         )
-    }
-
-    /// Return a new `Index` instance from the given `path`, which should contain a bare or non-bare
-    /// clone of the `crates.io` index.
-    /// If the directory does not contain the repository or does not exist, it will be cloned from
-    /// the official location automatically (with complete history).
-    pub fn from_path_or_cloned(path: impl AsRef<Path>) -> Result<Index, Error> {
-        Index::from_path_or_cloned_with_options(path, CloneOptions::default())
     }
 }

--- a/src/index/init.rs
+++ b/src/index/init.rs
@@ -101,7 +101,7 @@ impl Index {
         repo.object_cache_size_if_unset(4 * 1024 * 1024);
         Ok(Index {
             repo,
-            remote_name: Some("origin"),
+            remote_name: Some("origin".into()),
             branch_name: "master",
             seen_ref_name: LAST_SEEN_REFNAME,
         })
@@ -148,9 +148,14 @@ impl Index {
         .apply_environment();
 
         repo.object_cache_size_if_unset(4 * 1024 * 1024);
+        let remote_name = repo
+            .remote_names()
+            .into_iter()
+            .next()
+            .map(ToOwned::to_owned);
         Ok(Index {
             repo,
-            remote_name: Some("origin"),
+            remote_name,
             branch_name: "master",
             seen_ref_name: LAST_SEEN_REFNAME,
         })

--- a/src/index/init.rs
+++ b/src/index/init.rs
@@ -1,7 +1,8 @@
-use crate::index::{CloneOptions, LAST_SEEN_REFNAME};
+use crate::index::{CloneOptions, CloneOptions2, LAST_SEEN_REFNAME};
 use crate::Index;
 use git_repository as git;
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
 
 /// The error returned by various initialization methods.
 #[derive(Debug, thiserror::Error)]
@@ -9,6 +10,18 @@ use std::path::Path;
 pub enum Error {
     #[error(transparent)]
     Clone(#[from] git2::Error),
+    #[error(transparent)]
+    Open(#[from] git::open::Error),
+}
+
+/// The error returned by various initialization methods.
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum Error2 {
+    #[error(transparent)]
+    PrepareClone(#[from] git::clone::prepare::Error),
+    #[error(transparent)]
+    Fetch(#[from] git::clone::fetch::Error),
     #[error(transparent)]
     Open(#[from] git::open::Error),
 }
@@ -92,6 +105,68 @@ impl Index {
             branch_name: "master",
             seen_ref_name: LAST_SEEN_REFNAME,
         })
+    }
+
+    /// Return a new `Index` instance from the given `path`, which should contain a bare clone of the `crates.io` index.
+    /// If the directory does not contain the repository or does not exist, it will be cloned from
+    /// the official location automatically (with complete history).
+    ///
+    /// An error will occour if the repository exists and the remote URL does not match the given repository URL.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::atomic::AtomicBool;
+    /// use crates_index_diff::{Index, index, git};
+    ///
+    /// # let path = tempdir::TempDir::new("index").unwrap();
+    /// // Note that credentials are automatically picked up from the standard git configuration.
+    /// let mut options = index::CloneOptions2 {
+    ///   url: "https://github.com/rust-lang/staging.crates.io-index".into(),
+    /// };
+    ///
+    ///
+    /// let index = Index::from_path_or_cloned_with_options2(path, git::progress::Discard, &AtomicBool::default(), options)?;
+    /// # Ok::<(), crates_index_diff::index::init::Error2>(())
+    /// ```
+    pub fn from_path_or_cloned_with_options2(
+        path: impl AsRef<Path>,
+        progress: impl git::Progress,
+        should_interrupt: &AtomicBool,
+        CloneOptions2 { url }: CloneOptions2,
+    ) -> Result<Index, Error2> {
+        let path = path.as_ref();
+        let mut repo = match git::open(path) {
+            Ok(repo) => repo,
+            Err(git::open::Error::NotARepository(_)) => {
+                let (repo, _out) =
+                    git::prepare_clone_bare(url, path)?.fetch_only(progress, should_interrupt)?;
+                repo
+            }
+            Err(err) => return Err(err.into()),
+        }
+        .apply_environment();
+
+        repo.object_cache_size_if_unset(4 * 1024 * 1024);
+        Ok(Index {
+            repo,
+            remote_name: Some("origin"),
+            branch_name: "master",
+            seen_ref_name: LAST_SEEN_REFNAME,
+        })
+    }
+
+    /// Return a new `Index` instance from the given `path`, which should contain a bare or non-bare
+    /// clone of the `crates.io` index.
+    /// If the directory does not contain the repository or does not exist, it will be cloned from
+    /// the official location automatically (with complete history).
+    pub fn from_path_or_cloned2(path: impl AsRef<Path>) -> Result<Index, Error2> {
+        Index::from_path_or_cloned_with_options2(
+            path,
+            git::progress::Discard,
+            &AtomicBool::default(),
+            CloneOptions2::default(),
+        )
     }
 
     /// Return a new `Index` instance from the given `path`, which should contain a bare or non-bare

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -5,32 +5,15 @@ use std::str;
 static INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
 static LAST_SEEN_REFNAME: &str = "refs/heads/crates-index-diff_last-seen";
 
-/// Options for use in `Index::from_path_or_cloned_with_options`
-pub struct CloneOptions<'a> {
-    /// The url from which the repository should be cloned.
-    pub repository_url: String,
-    /// Git2 fetch options to control exactly how to clone.
-    pub fetch_options: Option<git2::FetchOptions<'a>>,
-}
-
-impl<'a> Default for CloneOptions<'a> {
-    fn default() -> Self {
-        CloneOptions {
-            repository_url: INDEX_GIT_URL.into(),
-            fetch_options: None,
-        }
-    }
-}
-
 /// Options for cloning the crates-io index.
-pub struct CloneOptions2 {
+pub struct CloneOptions {
     /// The url to clone the crates-index repository from.
     pub url: String,
 }
 
-impl Default for CloneOptions2 {
+impl Default for CloneOptions {
     fn default() -> Self {
-        CloneOptions2 {
+        CloneOptions {
             url: INDEX_GIT_URL.into(),
         }
     }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -22,6 +22,20 @@ impl<'a> Default for CloneOptions<'a> {
     }
 }
 
+/// Options for cloning the crates-io index.
+pub struct CloneOptions2 {
+    /// The url to clone the crates-index repository from.
+    pub url: String,
+}
+
+impl Default for CloneOptions2 {
+    fn default() -> Self {
+        CloneOptions2 {
+            url: INDEX_GIT_URL.into(),
+        }
+    }
+}
+
 /// Access
 impl Index {
     /// Return the crates.io repository.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,5 @@
 pub mod index;
 mod types;
 
-pub use git2;
 pub use git_repository as git;
 pub use types::{Change, CrateVersion, Dependency, Index};

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ pub struct Index {
     pub branch_name: &'static str,
     /// The name of the symbolic name of the remote to fetch from.
     /// If `None`, obtain the remote name from the configuration of the currently checked-out branch.
-    pub remote_name: Option<&'static str>,
+    pub remote_name: Option<String>,
     /// The git repository to use for diffing
     pub(crate) repo: git::Repository,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,8 @@ pub struct Index {
     /// The name of the branch to fetch. This value also affects the tracking branch.
     pub branch_name: &'static str,
     /// The name of the symbolic name of the remote to fetch from.
-    pub remote_name: &'static str,
+    /// If `None`, obtain the remote name from the configuration of the currently checked-out branch.
+    pub remote_name: Option<&'static str>,
     /// The git repository to use for diffing
     pub(crate) repo: git::Repository,
 }

--- a/tests/index/mod.rs
+++ b/tests/index/mod.rs
@@ -18,7 +18,7 @@ fn peek_changes() -> crate::Result {
         "marker ref doesn't exist"
     );
     let (changes, last_seen_revision) =
-        index.peek_changes_with_options2(git::progress::Discard, &AtomicBool::default())?;
+        index.peek_changes_with_options(git::progress::Discard, &AtomicBool::default())?;
     assert_eq!(
         changes.len(),
         NUM_CHANGES_SINCE_EVER,
@@ -44,14 +44,14 @@ fn peek_changes() -> crate::Result {
 fn clone_if_needed() {
     let tmp = TempDir::new().unwrap();
     let no_interrupt = &AtomicBool::default();
-    Index::from_path_or_cloned_with_options2(
+    Index::from_path_or_cloned_with_options(
         tmp.path(),
         git::progress::Discard,
         no_interrupt,
         clone_options(),
     )
     .expect("successful clone to be created");
-    Index::from_path_or_cloned_with_options2(
+    Index::from_path_or_cloned_with_options(
         tmp.path(),
         git::progress::Discard,
         no_interrupt,
@@ -65,7 +65,7 @@ fn changes_since_last_fetch() {
     let (mut index, _tmp) = index_rw().unwrap();
     let repo = index.repository();
     assert!(index.last_seen_reference().is_err(), "no marker exists");
-    let num_changes_since_first_commit = index.fetch_changes2().unwrap().len();
+    let num_changes_since_first_commit = index.fetch_changes().unwrap().len();
     assert_eq!(
         num_changes_since_first_commit, NUM_CHANGES_SINCE_EVER,
         "all changes since ever"
@@ -90,7 +90,7 @@ fn changes_since_last_fetch() {
             "resetting to previous commit",
         )
         .expect("reset success");
-    let num_seen_after_reset = index.fetch_changes2().unwrap().len();
+    let num_seen_after_reset = index.fetch_changes().unwrap().len();
     assert_eq!(
         index.last_seen_reference().unwrap().target(),
         remote_main.target(),
@@ -102,7 +102,7 @@ fn changes_since_last_fetch() {
     );
 
     assert_eq!(
-        index.fetch_changes2().unwrap().len(),
+        index.fetch_changes().unwrap().len(),
         0,
         "nothing if there was no change"
     );
@@ -140,7 +140,7 @@ fn changes_since_last_fetch() {
             "adjust to simulate remote with new squashed history",
         )
         .unwrap();
-    let changes = index.fetch_changes2().unwrap();
+    let changes = index.fetch_changes().unwrap();
     assert_eq!(changes.len(), 1);
     assert_eq!(
         changes
@@ -158,7 +158,7 @@ fn index_ro() -> crate::Result<Index> {
 
 fn index_rw() -> crate::Result<(Index, TempDir)> {
     let tmp = TempDir::new().unwrap();
-    let mut index = Index::from_path_or_cloned_with_options2(
+    let mut index = Index::from_path_or_cloned_with_options(
         tmp.path(),
         git::progress::Discard,
         &AtomicBool::default(),
@@ -177,8 +177,8 @@ fn fixture_dir() -> crate::Result<PathBuf> {
     )
 }
 
-fn clone_options() -> crates_index_diff::index::CloneOptions2 {
-    crates_index_diff::index::CloneOptions2 {
+fn clone_options() -> crates_index_diff::index::CloneOptions {
+    crates_index_diff::index::CloneOptions {
         url: fixture_dir().unwrap().join("base").display().to_string(),
     }
 }

--- a/tests/index/mod.rs
+++ b/tests/index/mod.rs
@@ -1,6 +1,8 @@
 use crates_index_diff::Index;
+use git_repository as git;
 use git_testtools::tempfile::TempDir;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 
 mod changes_between_commits;
 
@@ -14,7 +16,8 @@ fn peek_changes() -> crate::Result {
         index.last_seen_reference().is_err(),
         "marker ref doesn't exist"
     );
-    let (changes, last_seen_revision) = index.peek_changes()?;
+    let (changes, last_seen_revision) =
+        index.peek_changes_with_options2(git::progress::Discard, &AtomicBool::default())?;
     assert_eq!(
         changes.len(),
         NUM_CHANGES_SINCE_EVER,

--- a/tests/index/mod.rs
+++ b/tests/index/mod.rs
@@ -93,7 +93,7 @@ fn changes_since_last_fetch() -> crate::Result {
 
     // now the remote has squashed their history, we should still be able to get the correct changes.
     git2::Repository::open(repo.git_dir())?.remote("local", repo.git_dir().to_str().unwrap())?;
-    index.remote_name = "local";
+    index.remote_name = Some("local");
     index
         .repository()
         .find_reference("refs/heads/main")?


### PR DESCRIPTION
### Tasks

* [x] fetch with `gitoxide`
* [x] clone with `gitoxide`
* [x] make huge changelog note that clarifies that advanced SSH auth (or any auth beyond HTTP) isn't supported anymore until `gitoxide` catches up
