### PR TITLE
fix #33

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,11 @@ jobs:
       run: make test
     - name: docs
       run: cargo doc
+    - name: usage as dependency
+      run: |
+          cargo init user
+          cd user
+          cargo add --path ..
+          cargo check
+           
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ http-reqwest = ["git-repository/blocking-http-transport-reqwest-rust-tls"]
 [dependencies]
 git-repository = { version = "0.29.0", default-features = false, features = ["max-performance-safe", "blocking-network-client"] }
 serde = { version = "1", features = ["std", "derive"] }
-hex = "0.4.3"
-smartstring = "1.0.1"
+hex = { version = "0.4.3", features = ["serde"] }
+smartstring = { version = "1.0.1", features = ["serde"] }
 serde_json = "1"
 bstr = "1.0.1"
 thiserror = "1.0.32"


### PR DESCRIPTION
It's strange that something in the dependency graph turns on
serde automatically there, even though that doesn't happen
when compiling with the crate as dependency.
