### PR TITLE
upgrade gix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ required-features = ["max-performance"]
 
 [features]
 default = ["http-curl"]
-## Configure `git-repository` to use maximum performance.
+## Configure `gix` to use maximum performance, but with greater compatibility.
+max-performance-safe = ["gix/max-performance-safe"]
+## Configure `gix` to use maximum performance.
 max-performance = ["gix/max-performance"]
 ## Use libcurl for all http/https interactions. Supports many git http settings, but needs a C toolchain to build.
 http-curl = ["gix/blocking-http-transport-curl"]
@@ -35,7 +37,7 @@ http-reqwest = ["gix/blocking-http-transport-reqwest-rust-tls"]
 
 
 [dependencies]
-gix = { version = "0.50.0", default-features = false, features = ["max-performance-safe", "blocking-network-client" ] }
+gix = { version = "0.54.1", default-features = false, features = ["blocking-network-client", "blob-diff", "revision"] }
 serde = { version = "1", features = ["std", "derive"] }
 hex = { version = "0.4.3", features = ["serde"] }
 smartstring = { version = "1.0.1", features = ["serde"] }

--- a/src/index/diff/mod.rs
+++ b/src/index/diff/mod.rs
@@ -113,7 +113,7 @@ impl Index {
         order: Order,
     ) -> Result<(Vec<Change>, gix::hash::ObjectId), Error>
     where
-        P: gix::Progress,
+        P: gix::NestedProgress,
         P::SubProgress: 'static,
     {
         let repo = &self.repo;
@@ -362,7 +362,7 @@ impl Index {
         order: Order,
     ) -> Result<Vec<Change>, Error>
     where
-        P: gix::Progress,
+        P: gix::NestedProgress,
         P::SubProgress: 'static,
     {
         let (changes, to) = self.peek_changes_with_options(progress, should_interrupt, order)?;

--- a/src/index/init.rs
+++ b/src/index/init.rs
@@ -46,7 +46,7 @@ impl Index {
         CloneOptions { url }: CloneOptions,
     ) -> Result<Index, Error>
     where
-        P: gix::Progress,
+        P: gix::NestedProgress,
         P::SubProgress: 'static,
     {
         let path = path.as_ref();


### PR DESCRIPTION
This may produce smaller binaries.

Further, no performance option is set anymore to leave this in the hands of
the final binary.
