### PR TITLE
various improvements, investigate strong ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,5 +49,5 @@ hashbrown = { version = "0.14.0", features = ["raw"] }
 
 [dev-dependencies]
 gix-testtools = "0.12.0"
-crates-index = { version = "2.0.0", default-features = false, features = ["git-performance", "git-https"] }
+crates-index = { version = "2.2.0", default-features = false, features = ["git-performance", "git-https"] }
 tempdir = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ http-reqwest = ["gix/blocking-http-transport-reqwest-rust-tls"]
 
 
 [dependencies]
-gix = { version = "0.54.1", default-features = false, features = ["blocking-network-client", "blob-diff", "revision"] }
+gix = { version = "0.55.2", default-features = false, features = ["blocking-network-client", "blob-diff", "revision"] }
 serde = { version = "1", features = ["std", "derive"] }
 hex = { version = "0.4.3", features = ["serde"] }
 smartstring = { version = "1.0.1", features = ["serde"] }
@@ -49,5 +49,5 @@ hashbrown = { version = "0.14.0", features = ["raw"] }
 
 [dev-dependencies]
 gix-testtools = "0.12.0"
-crates-index = { version = "2.2.0", default-features = false, features = ["git-performance", "git-https"] }
+crates-index = { version = "2.3.0", default-features = false, features = ["git-performance", "git-https"] }
 tempdir = "0.3.5"

--- a/src/index/diff/mod.rs
+++ b/src/index/diff/mod.rs
@@ -215,8 +215,8 @@ impl Index {
     /// # Grouping and Ordering
     ///
     /// The changes are grouped by the crate they belong to.
-    /// The order of the changes for each crate are **non-deterministic**.
-    /// The order of crates is also **non-deterministic**.
+    /// The order of the changes for each crate is **deterministic** as they are ordered by line number, ascending.
+    /// The order of crates is **non-deterministic**.
     ///
     /// If a specific order is required, the changes must be sorted by the caller.
     pub fn changes_between_commits(
@@ -256,7 +256,8 @@ impl Index {
     ///
     /// # Grouping and Ordering
     ///
-    /// Note that the order of the changes for each crate are **non-deterministic**, should they happen within one commit.
+    /// Note that the order of the changes for each crate is **deterministic**, should they happen within one commit,
+    /// as the ordering is imposed to be by line number, ascending.
     /// Typically one commit does not span multiple crates, but if it does, for instance when rollups happen,
     /// then the order of crates is also **non-deterministic**.
     ///
@@ -406,7 +407,7 @@ impl Index {
     /// # Grouping and Ordering
     ///
     /// The changes are grouped by the crate they belong to.
-    /// The order of the changes for each crate are **non-deterministic**.
+    /// The order of the changes for each crate is **deterministic** as they are ordered by line number, ascending.
     /// The order of crates is also **non-deterministic**.
     ///
     /// If a specific order is required, the changes must be sorted by the caller.

--- a/src/index/diff/mod.rs
+++ b/src/index/diff/mod.rs
@@ -86,14 +86,14 @@ impl Index {
         )
     }
 
-    /// Return all `Change`s that are observed between the last time `peek_changes*(…)` was called
+    /// Return all [`Change`]s that are observed between the last time `peek_changes*(…)` was called
     /// and the latest state of the `crates.io` index repository, which is obtained by fetching
     /// the remote called `origin` or whatever is configured for the current `HEAD` branch and lastly
     /// what it should be based on knowledge about he crates index.
-    /// The `last_seen_reference()` will not be created or updated.
+    /// The [`Self::last_seen_reference()`] will not be created or updated.
     /// The second field in the returned tuple is the commit object to which the changes were provided.
-    /// If one would set the `last_seen_reference()` to that object, the effect is exactly the same
-    /// as if `fetch_changes(…)` had been called.
+    /// If one would set the [`Self::last_seen_reference()`] to that object, the effect is exactly the same
+    /// as if [`Self::fetch_changes()`] had been called.
     ///
     /// The `progress` and `should_interrupt` parameters are used to provide progress for fetches and allow
     /// these operations to be interrupted gracefully.
@@ -204,13 +204,16 @@ impl Index {
         ))
     }
 
-    /// Similar to `changes()`, but requires `from` and `to` objects to be provided. They may point
+    /// Similar to [`Self::changes()`], but requires `from` and `to` objects to be provided. They may point
     /// to either `Commit`s or `Tree`s.
     ///
     /// # Returns
     ///
     /// A list of atomic changes that were performed on the index
     /// between the two revisions.
+    ///
+    /// # Grouping and Ordering
+    ///
     /// The changes are grouped by the crate they belong to.
     /// The order of the changes for each crate are **non-deterministic**.
     /// The order of crates is also **non-deterministic**.
@@ -238,7 +241,7 @@ impl Index {
         delegate.into_result()
     }
 
-    /// Similar to `changes()`, but requires `ancestor_commit` and `current_commit` objects to be provided
+    /// Similar to [`Self::changes()`], but requires `ancestor_commit` and `current_commit` objects to be provided
     /// with `ancestor_commit` being in the ancestry of `current_commit`.
     ///
     /// If the invariants regarding `ancestor_commit` and `current_commit` are not upheld, we fallback
@@ -250,6 +253,13 @@ impl Index {
     /// A list of atomic changes that were performed on the index
     /// between the two revisions, but looking at it one commit at a time, along with the `Order`
     /// that the changes are actually in in case one of the invariants wasn't met.
+    ///
+    /// # Grouping and Ordering
+    ///
+    /// Note that the order of the changes for each crate are **non-deterministic**, should they happen within one commit.
+    /// Typically one commit does not span multiple crates, but if it does, for instance when rollups happen,
+    /// then the order of crates is also **non-deterministic**.
+    ///
     pub fn changes_between_ancestor_commits(
         &self,
         ancestor_commit: impl Into<gix::hash::ObjectId>,
@@ -337,10 +347,10 @@ impl Index {
         )
     }
 
-    /// Return all `Change`s that are observed between the last time this method was called
+    /// Return all [`Change`]s that are observed between the last time this method was called
     /// and the latest state of the `crates.io` index repository, which is obtained by fetching
     /// the remote called `origin`.
-    /// The `last_seen_reference()` will be created or adjusted to point to the latest fetched
+    /// The [`Self::last_seen_reference()`] will be created or adjusted to point to the latest fetched
     /// state, which causes this method to have a different result each time it is called.
     ///
     /// The `progress` and `should_interrupt` parameters are used to provide progress for fetches and allow
@@ -392,6 +402,9 @@ impl Index {
     ///
     /// A list of atomic chanes that were performed on the index
     /// between the two revisions.
+    ///
+    /// # Grouping and Ordering
+    ///
     /// The changes are grouped by the crate they belong to.
     /// The order of the changes for each crate are **non-deterministic**.
     /// The order of crates is also **non-deterministic**.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Have a look at the real-world usage to learn more about it:
 //! [crates-io-cli](https://github.com/Byron/crates-io-cli-rs/blob/b7a39ad8ef68adb81b2d8a7e552cb0a2a73f7d5b/src/main.rs#L62)
-#![deny(missing_docs, rust_2018_idioms)]
+#![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
 ///
 pub mod index;

--- a/tests/index/changes_between_commits.rs
+++ b/tests/index/changes_between_commits.rs
@@ -44,13 +44,12 @@ fn updates_before_yanks_are_picked_up() -> crate::Result {
     let repo = index.repository();
     let from = repo.rev_parse_single("@^{/updating ansi-color-codec 0.3.11}~1")?;
     let to = repo.rev_parse_single("@^{/yanking ansi-color-codec 0.3.5}")?;
-    let mut changes = index.changes_between_commits(from, to)?;
+    let changes = index.changes_between_commits(from, to)?;
 
     assert_eq!(changes.len(), 3, "1 update and 2 yanks");
-    changes.sort_by_key(|change| change.versions()[0].version.clone());
-    assert_eq!(changes[0].added().expect("first updated").version, "0.3.11");
-    assert_eq!(changes[1].yanked().expect("second yanked").version, "0.3.4");
-    assert_eq!(changes[2].yanked().expect("third yanked").version, "0.3.5");
+    assert_eq!(changes[0].yanked().expect("second yanked").version, "0.3.4");
+    assert_eq!(changes[1].yanked().expect("third yanked").version, "0.3.5");
+    assert_eq!(changes[2].added().expect("first updated").version, "0.3.11");
 
     let (mut changes, order) = index.changes_between_ancestor_commits(from, to)?;
     assert_eq!(


### PR DESCRIPTION
Various improvements, related to https://github.com/rust-lang/docs.rs/issues/2295


### Tasks

* [x] figure out what's happening
* [x] is there a way to maintain the order of operations per crate?
