### PR TITLE
upgrade gix & gix-testtools 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ http-reqwest = ["gix/blocking-http-transport-reqwest-rust-tls"]
 
 
 [dependencies]
-gix = { version = "0.72.1", default-features = false, features = ["blocking-network-client", "blob-diff", "revision"] }
+gix = { version = "0.74.1", default-features = false, features = ["blocking-network-client", "blob-diff", "revision"] }
 serde = { version = "1", features = ["std", "derive"] }
 hex = { version = "0.4.3", features = ["serde"] }
 smartstring = { version = "1.0.1", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,6 @@ hashbrown = { version = "0.14.0", features = ["raw"] }
 reqwest = { version = "0.12", features = ["blocking"] }
 
 [dev-dependencies]
-gix-testtools = "0.15.0"
+gix-testtools = "0.16.1"
 crates-index = { version = "3.0.0", default-features = false, features = ["git-performance", "git-https"] }
 tempdir = "0.3.5"


### PR DESCRIPTION
the hashbrown update is a little more effort since they dropped the `RawTable` and [recommend using `HashTable` instead](https://github.com/rust-lang/hashbrown/issues/545#issuecomment-2303232041). 


( regarding hashbrown, [0.15.0](https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#v0150---2024-10-01) )