### PR TITLE
upgrade hashbrown to 0.16.0, migrate from RawTable to HashTable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = "1"
 bstr = "1.0.1"
 thiserror = "2"
 ahash = "0.8.0"
-hashbrown = { version = "0.14.0", features = ["raw"] }
+hashbrown = { version = "0.16.0" }
 reqwest = { version = "0.12", features = ["blocking"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This migrates to [`hashbrown` 0.16.0](https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#0160---2025-08-28), [including a breaking change where they made `raw::RawTable` private](https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#v0150---2024-10-01). 

They [recommend migrating to `HashTable` instead](https://github.com/rust-lang/hashbrown/issues/545#issuecomment-2303232041), arguing that it's a safe interface and provides all needed functionality. 

It was a little easier than I thought, as I understand the current logic. 

Are there some performance tests that can be run? 


I compared the documentation for both changes, and I think my change is fine. 

- [`insert`](https://docs.rs/hashbrown/0.14.0/hashbrown/raw/struct.RawTable.html#method.insert) -> [`insert_unique`](https://docs.rs/hashbrown/latest/hashbrown/struct.HashTable.html#method.insert_unique)
- [`remove_entry`](https://docs.rs/hashbrown/0.14.0/hashbrown/raw/struct.RawTable.html#method.remove_entry) -> [`find_entry` ](https://docs.rs/hashbrown/latest/hashbrown/struct.HashTable.html#method.find_entry) & [`OccupiedEntry::remove`](https://docs.rs/hashbrown/latest/hashbrown/hash_table/struct.OccupiedEntry.html#method.remove)