### PR TITLE
fix some small clippy errors, Box<> big error variants to reduce result memory footprint (and make clippy happy)

### DIFF
--- a/src/index/diff/delegate.rs
+++ b/src/index/diff/delegate.rs
@@ -86,7 +86,6 @@ impl Delegate {
                     let old = previous_id.object()?.into_blob();
                     let new = id.object()?.into_blob();
                     let mut old_lines = AHashSet::with_capacity(1024);
-                    let location = location;
                     for (number, line) in old.data.lines().enumerate() {
                         old_lines.insert(Line(number, line));
                     }

--- a/src/index/diff/github.rs
+++ b/src/index/diff/github.rs
@@ -10,7 +10,7 @@ pub(crate) enum FastPath {
 /// extract username & repository from a fetch URL, only if it's on Github.
 fn user_and_repo_from_url_if_github(fetch_url: &gix::Url) -> Option<(String, String)> {
     let url = Url::parse(&fetch_url.to_string()).ok()?;
-    if !(url.host_str() == Some("github.com")) {
+    if url.host_str() != Some("github.com") {
         return None;
     }
 

--- a/src/index/diff/mod.rs
+++ b/src/index/diff/mod.rs
@@ -186,7 +186,7 @@ impl Index {
                 github::has_changes(&url, &from, self.branch_name)?,
                 github::FastPath::UpToDate
             ) {
-                from.clone()
+                from
             } else {
                 let res: gix::remote::fetch::Outcome = remote
                     .connect(gix::remote::Direction::Fetch)?

--- a/src/index/diff/mod.rs
+++ b/src/index/diff/mod.rs
@@ -32,19 +32,19 @@ pub enum Order {
 #[allow(missing_docs)]
 pub enum Error {
     #[error("Couldn't update marker reference")]
-    ReferenceEdit(#[from] gix::reference::edit::Error),
+    ReferenceEdit(#[from] Box<gix::reference::edit::Error>),
     #[error("Failed to parse rev-spec to determine which revisions to diff")]
-    RevParse(#[from] gix::revision::spec::parse::Error),
+    RevParse(#[from] Box<gix::revision::spec::parse::Error>),
     #[error(transparent)]
-    DiffRewrites(#[from] gix::diff::new_rewrites::Error),
+    DiffRewrites(#[from] Box<gix::diff::new_rewrites::Error>),
     #[error("Couldn't find blob that showed up when diffing trees")]
-    FindObject(#[from] gix::object::find::existing::Error),
+    FindObject(#[from] Box<gix::object::find::existing::Error>),
     #[error("Couldn't get the tree of a commit for diffing purposes")]
-    PeelToTree(#[from] gix::object::peel::to_kind::Error),
+    PeelToTree(#[from] Box<gix::object::peel::to_kind::Error>),
     #[error("Failed to diff two trees to find changed crates")]
-    Diff(#[from] gix::diff::options::init::Error),
+    Diff(#[from] Box<gix::diff::options::init::Error>),
     #[error(transparent)]
-    DiffForEach(#[from] gix::object::tree::diff::for_each::Error),
+    DiffForEach(#[from] Box<gix::object::tree::diff::for_each::Error>),
     #[error("Failed to decode {line:?} in file {file_name:?} as crate version")]
     VersionDecode {
         source: serde_json::Error,
@@ -52,17 +52,17 @@ pub enum Error {
         line: bstr::BString,
     },
     #[error(transparent)]
-    FindRemote(#[from] gix::remote::find::existing::Error),
+    FindRemote(#[from] Box<gix::remote::find::existing::Error>),
     #[error(transparent)]
-    FindReference(#[from] gix::reference::find::existing::Error),
+    FindReference(#[from] Box<gix::reference::find::existing::Error>),
     #[error(transparent)]
-    Connect(#[from] gix::remote::connect::Error),
+    Connect(#[from] Box<gix::remote::connect::Error>),
     #[error(transparent)]
-    PrepareFetch(#[from] gix::remote::fetch::prepare::Error),
+    PrepareFetch(#[from] Box<gix::remote::fetch::prepare::Error>),
     #[error(transparent)]
-    Fetch(#[from] gix::remote::fetch::Error),
+    Fetch(#[from] Box<gix::remote::fetch::Error>),
     #[error(transparent)]
-    InitAnonymousRemote(#[from] gix::remote::init::Error),
+    InitAnonymousRemote(#[from] Box<gix::remote::init::Error>),
     #[error("Could not find local tracking branch for remote branch {name:?} in any of {} fetched refs", mappings.len()
     )]
     NoMatchingBranch {
@@ -72,6 +72,20 @@ pub enum Error {
     #[error("Error when fetching GitHub fastpath.")]
     GithubFetch(#[from] reqwest::Error),
 }
+
+impl_from_boxed!(gix::diff::new_rewrites::Error => Error::DiffRewrites);
+impl_from_boxed!(gix::diff::options::init::Error => Error::Diff);
+impl_from_boxed!(gix::object::find::existing::Error => Error::FindObject);
+impl_from_boxed!(gix::object::peel::to_kind::Error => Error::PeelToTree);
+impl_from_boxed!(gix::object::tree::diff::for_each::Error => Error::DiffForEach);
+impl_from_boxed!(gix::reference::edit::Error => Error::ReferenceEdit);
+impl_from_boxed!(gix::reference::find::existing::Error => Error::FindReference);
+impl_from_boxed!(gix::remote::connect::Error => Error::Connect);
+impl_from_boxed!(gix::remote::fetch::Error => Error::Fetch);
+impl_from_boxed!(gix::remote::fetch::prepare::Error => Error::PrepareFetch);
+impl_from_boxed!(gix::remote::find::existing::Error => Error::FindRemote);
+impl_from_boxed!(gix::remote::init::Error => Error::InitAnonymousRemote);
+impl_from_boxed!(gix::revision::spec::parse::Error => Error::RevParse);
 
 /// Find changes without modifying the underling repository
 impl Index {

--- a/src/index/init.rs
+++ b/src/index/init.rs
@@ -9,12 +9,16 @@ use std::sync::atomic::AtomicBool;
 #[allow(missing_docs)]
 pub enum Error {
     #[error(transparent)]
-    PrepareClone(#[from] gix::clone::Error),
+    PrepareClone(#[from] Box<gix::clone::Error>),
     #[error(transparent)]
-    Fetch(#[from] gix::clone::fetch::Error),
+    Fetch(#[from] Box<gix::clone::fetch::Error>),
     #[error(transparent)]
-    Open(#[from] gix::open::Error),
+    Open(#[from] Box<gix::open::Error>),
 }
+
+impl_from_boxed!(gix::clone::Error => Error::PrepareClone);
+impl_from_boxed!(gix::clone::fetch::Error => Error::Fetch);
+impl_from_boxed!(gix::open::Error => Error::Open);
 
 /// Initialization
 impl Index {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -4,6 +4,28 @@ use std::str;
 static INDEX_GIT_URL: &str = "https://github.com/rust-lang/crates.io-index";
 static LAST_SEEN_REFNAME: &str = "refs/heads/crates-index-diff_last-seen";
 
+/// Declarative macro to generate `impl From<Src> for Error` where the source
+/// error value is boxed into the given `Error` enum variant.
+///
+/// Usage:
+/// impl_from_boxed!(gix::object::find::existing::Error => ErrorEnum::FindObject);
+/// impl_from_boxed!(gix::remote::find::existing::Error => ErrorEnum::FindRemote);
+///
+/// See also:
+/// * https://rust-lang.github.io/rust-clippy/stable/index.html#/result_large_err
+/// * https://github.com/dtolnay/thiserror/pull/419
+/// * https://github.com/dtolnay/thiserror/pull/418
+/// * https://github.com/dtolnay/thiserror/issues/302
+macro_rules! impl_from_boxed {
+    ($src:path => $err:ident::$variant:ident) => {
+        impl From<$src> for $err {
+            fn from(value: $src) -> Self {
+                Self::$variant(Box::new(value))
+            }
+        }
+    };
+}
+
 /// Options for cloning the crates-io index.
 pub struct CloneOptions {
     /// The url to clone the crates-index repository from.

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -38,7 +38,7 @@ impl Index {
     }
 }
 
-///
+/// Main index diff functionality
 pub mod diff;
-///
+/// initial index repo loading & cloning
 pub mod init;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! [crates-io-cli](https://github.com/Byron/crates-io-cli-rs/blob/b7a39ad8ef68adb81b2d8a7e552cb0a2a73f7d5b/src/main.rs#L62)
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
-///
+/// Access to the main `Index` type and related functionality.
 pub mod index;
 mod types;
 /// Access to all `gitoxide` functionality.


### PR DESCRIPTION
Interesting related to the `Box<>`: 
* https://rust-lang.github.io/rust-clippy/stable/index.html#/result_large_err
* https://github.com/dtolnay/thiserror/pull/419
* https://github.com/dtolnay/thiserror/pull/418
* https://github.com/dtolnay/thiserror/issues/302


I'm happy to discuss / revert / change everything :) 