### PR TITLE
feat: provide parsed semver Version/Req via method on CrateVersion & Dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "tests/baseline_atomic.rs"
 required-features = ["max-performance"]
 
 [features]
-default = ["http-curl"]
+default = ["http-curl", "semver"]
 ## Configure `gix` to use maximum performance, but with greater compatibility.
 max-performance-safe = ["gix/max-performance-safe"]
 ## Configure `gix` to use maximum performance.
@@ -31,6 +31,8 @@ max-performance = ["gix/max-performance"]
 http-curl = ["gix/blocking-http-transport-curl"]
 ## Use reqwest along with pure-rust TLS implementations. Needs no C toolchain, but might not be parity in features compared to curl.
 http-reqwest = ["gix/blocking-http-transport-reqwest-rust-tls"]
+## provide semver support for release version numbers
+semver = ["dep:semver"]
 
 
 [dependencies]
@@ -44,6 +46,7 @@ thiserror = "2"
 ahash = "0.8.0"
 hashbrown = { version = "0.16.0" }
 reqwest = { version = "0.12", features = ["blocking"] }
+semver = { version = "1.0.27", features = ["serde"], optional = true }
 
 [dev-dependencies]
 gix-testtools = "0.16.1"

--- a/tests/version/mod.rs
+++ b/tests/version/mod.rs
@@ -1,4 +1,6 @@
 use crates_index_diff::*;
+use semver::{Version, VersionReq};
+use serde_json::json;
 use std::collections::HashMap;
 
 #[test]
@@ -14,6 +16,7 @@ fn parse_crate_version() {
     }"#,
     )
     .unwrap();
+    assert_eq!(c.version(), Version::new(1, 0, 0));
     assert_eq!(
         c,
         CrateVersion {
@@ -21,6 +24,81 @@ fn parse_crate_version() {
             yanked: true,
             version: "1.0.0".into(),
             dependencies: Vec::new(),
+            features: HashMap::new(),
+            checksum: Default::default()
+        }
+    );
+}
+
+#[test]
+fn parse_dependency() {
+    let d: Dependency = serde_json::from_value(json!({
+        "name": "dep_crate",
+        "req": "^1.2.3",
+        "features": ["feature1", "feature2"],
+        "optional": false,
+        "default_features": true,
+    }))
+    .unwrap();
+    assert_eq!(d.required_version(), VersionReq::parse("^1.2.3").unwrap());
+    assert_eq!(
+        d,
+        Dependency {
+            name: "dep_crate".into(),
+            required_version: "^1.2.3".into(),
+            features: vec!["feature1".into(), "feature2".into()],
+            optional: false,
+            default_features: true,
+            target: None,
+            kind: None,
+            package: None
+        }
+    );
+}
+
+#[test]
+fn parse_crate_version_with_dependencies() {
+    let c: CrateVersion = serde_json::from_value(json!({
+        "name": "test",
+        "vers": "1.0.0",
+        "cksum": "0000000000000000000000000000000000000000000000000000000000000000",
+        "features" : {},
+        "deps" : [
+            {
+                "name": "dep_crate",
+                "req": ">=1.2.3, <1.8.0",
+                "features": ["feature1", "feature2"],
+                "optional": false,
+                "default_features": true,
+                "target": "main",
+                "kind": "dev",
+                "package": "dep_package"
+            }
+        ],
+        "yanked": true
+    }))
+    .unwrap();
+    assert_eq!(c.version(), Version::new(1, 0, 0));
+    assert_eq!(
+        c.dependencies[0].required_version(),
+        VersionReq::parse(">=1.2.3, <1.8.0").unwrap()
+    );
+    assert_eq!(
+        c,
+        CrateVersion {
+            name: "test".into(),
+            yanked: true,
+            version: "1.0.0".into(),
+            dependencies: vec![Dependency {
+                name: "dep_crate".into(),
+                required_version: ">=1.2.3, <1.8.0".into(),
+                features: vec!["feature1".into(), "feature2".into()],
+                optional: false,
+                default_features: true,
+                target: Some("main".into()),
+                kind: Some(DependencyKind::Dev),
+                package: Some("dep_package".into())
+            }],
             features: HashMap::new(),
             checksum: Default::default()
         }


### PR DESCRIPTION
So, generally I have a tendency to try to express things in the type system, which would also mean I would love to have all the data structures in crates-index-diff using `semver::Version` for the version. Of course I totally see that this might be personal taste, and also might have an unwanted performance impact. 

I did some research [and it sounds like we can actually rely on the package version be compatible](https://rust-lang.zulipchat.com/#narrow/channel/246057-t-cargo/topic/does.20cargo.20guarantee.20package.20version.20is.20semver-parseable.3F/with/553277223). I also checked parts of the cargo- and crates.io source. And scanned the current crates.io index to see if any of the ~2 mio releases have a broken semver. But all is correct. 

So IMO ( adding some more info as code comment) we could add a method like this? Is that how you imagined it? 

I admit looking at the impact, it wouldn't be that big, only save us some `.parse` calls: https://github.com/syphar/docs.rs/commit/7e894085f8d7f8423278d7a5f422ab249715dc17. 

So, seeing all of that, we can do it, I can finish it up, but also it's not really necessary if you don't feel like it. 