### PR TITLE
update gix to 0.84, hashbrown to 0.17, gix-testtools to 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ sha256 = ["gix/sha256"]
 
 
 [dependencies]
-gix = { version = "0.83.0", default-features = false, features = ["blocking-network-client", "blob-diff", "revision"] }
+gix = { version = "0.84.0", default-features = false, features = ["blocking-network-client", "blob-diff", "revision"] }
 serde = { version = "1", features = ["std", "derive"] }
 hex = { version = "0.4.3", features = ["serde"] }
 smartstring = { version = "1.0.1", features = ["serde"] }
@@ -48,11 +48,11 @@ serde_json = "1"
 bstr = "1.0.1"
 thiserror = "2"
 ahash = "0.8.0"
-hashbrown = { version = "0.16.0" }
+hashbrown = { version = "0.17.1" }
 reqwest = { version = "0.13", features = ["blocking"] }
 semver = { version = "1.0.27", features = ["serde"], optional = true }
 
 [dev-dependencies]
-gix-testtools = "0.18.0"
+gix-testtools = "0.19.0"
 crates-index = { version = "3.0.0", default-features = false, features = ["git-performance", "git-https"] }
 tempdir = "0.3.5"


### PR DESCRIPTION
- https://github.com/GitoxideLabs/gitoxide/releases/tag/gix-v0.84.0
- https://github.com/GitoxideLabs/gitoxide/releases/tag/gix-testtools-v0.19.0 
- https://github.com/rust-lang/hashbrown/releases/tag/v0.17.0